### PR TITLE
Addition of nextclade database version and metrics to final report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[RSV-Viralrecon-v2.6.0-v1.1.0](https://github.com/wslh-bio/viralrecon/releases/tag/RSV-Viralrecon-v2.6.0-v1.1.0)] - 2025-11-11
+
+### Purpose
+
+This release of viralrecon is configured and modified for rsv sequencing at the Wisconsin State Laboratory of Hygiene.
+
+### Credits
+
+- [CJ Jossart](https://github.com/cjjossart)
+
+### Enhancements & fixes
+
+- Updated the final report to include nextclade database and metric information.
+- Addition of nextclade_multiqc_info module to add database information from nextclade database brought into the pipeline.
+- Addition of python script for nextclade_multiqc_info module to merge database information into tsv file for nextclade multiqc data.
+- Edited multiqc_to_custom_csv.py and multiqc_config_illumina.yml files to include addtional nextclade data.
+- Edited illumina.nf to include new module and include more columns in nextclade data channel.
+- Added the params.genome to the naming convention for reports to add rsva or rsvb to report name.
+
+### Parameters
+
+| Old parameter | New parameter |
+| ------------- | ------------- |
+|               |               |
+
+> **NB:** Parameter has been **updated** if both old and new parameter information is present.
+> **NB:** Parameter has been **added** if just the new parameter information is present.
+> **NB:** Parameter has been **removed** if new parameter information isn't present.
+
+### Software dependencies
+
+| Dependency  | Old version | New version |
+| ----------- | ----------- | ----------- |
+| `nextclade` | 2.12.0      | 3.9.1       |
+
+> **NB:** Dependency has been **updated** if both old and new version information is present.
+> **NB:** Dependency has been **added** if just the new version information is present.
+> **NB:** Dependency has been **removed** if new version information isn't present.
+
 ## [[RSV-Viralrecon-v2.6.0-v1.0.0](https://github.com/wslh-bio/viralrecon/releases/tag/RSV-Viralrecon-v2.6.0-v1.0.0)] - 2025-10-28
 
 ### Purpose

--- a/assets/multiqc_config_illumina.yml
+++ b/assets/multiqc_config_illumina.yml
@@ -205,6 +205,36 @@ custom_data:
         description: "Pangolin lineage inferred from the consensus sequence"
       "Nextclade clade":
         description: "Nextclade clade inferred from the consensus sequence"
+      "Nextclade database name":
+        description: "Nextclade database used for clade assignment"
+      "Nextclade database tag":
+        description: "Nextclade database tag used for clade assignment"
+      "Nextclade database reference name":
+        description: "Nextclade database reference name used for clade assignment"
+      "Nextclade database reference accession":
+        description: "Nextclade database reference accession used for clade assignment"
+      "Nextclade overall score":
+        description: "Nextclade overall QC score"
+      "Nextclade overall status":
+        description: "Nextclade overall QC status"
+      "Nextclade coverage":
+        description: "Nextclade coverage value"
+        format: "{:.2f}"
+      "Nextclade substitutions":
+        description: "Total number of substitutions identified by Nextclade"
+        format: "{:,.0f}"
+      "Nextclade deletions":
+        description: "Total number of deletions identified by Nextclade"
+        format: "{:,.0f}"
+      "Nextclade insertions":
+        description: "Total number of insertions identified by Nextclade"
+        format: "{:,.0f}"
+      "Nextclade frameshifts":
+        description: "Total number of frameshifts identified by Nextclade"
+        format: "{:,.0f}"
+      "Nextclade missing":
+        description: "Total number of missing bases identified by Nextclade"
+        format: "{:,.0f}"
 
     pconfig:
       id: "summary_variants_metrics_plot"

--- a/bin/multiqc_to_custom_csv.py
+++ b/bin/multiqc_to_custom_csv.py
@@ -154,7 +154,7 @@ def metrics_dict_to_file(file_field_list, multiqc_data_dir, out_file, valid_samp
             row_list = [k]
             for field in field_list:
                 if field in metrics_dict[k]:
-                    if metrics_dict[k][field]:
+                    if metrics_dict[k][field] is not None:
                         row_list.append(str(metrics_dict[k][field]).replace(",", ";"))
                     else:
                         row_list.append("NA")
@@ -236,8 +236,22 @@ def main(args=None):
             [("Pangolin lineage", ["lineage"])],
         ),
         (
-            "multiqc_nextclade_clade-plot.yaml",
-              [("Nextclade clade", ["clade"])]
+            "multiqc_nextclade_clade_db_info-plot.yaml",
+            [
+                ("Nextclade clade", ["clade"]),
+                ("Nextclade database name", ["nextclade_db_name"]),
+                ("Nextclade database tag", ["nextclade_db_version"]),
+                ("Nextclade database reference name", ["nextclade_db_reference_name"]),
+                ("Nextclade database reference accession", ["nextclade_db_reference_accession"]),
+                ("Nextclade overall score", ["qc.overallScore"]),
+                ("Nextclade overall status", ["qc.overallStatus"]),
+                ("Nextclade coverage", ["coverage"]),
+                ("Nextclade substitutions", ["totalSubstitutions"]),
+                ("Nextclade deletions", ["totalDeletions"]),
+                ("Nextclade insertions", ["totalInsertions"]),
+                ("Nextclade frameshifts", ["totalFrameShifts"]),
+                ("Nextclade missing", ["totalMissing"]),
+            ],   
         ),
     ]
 

--- a/bin/nextclade_multiqc_info.py
+++ b/bin/nextclade_multiqc_info.py
@@ -4,41 +4,37 @@ Edit Nextclade TSV file for MultiQC to include the database name,
 version, and reference accession number for each sample processed by nextclade_run.
 
 Usage:
-  nextclade_multiqc_info.py --db_dir <db_dir> --clade_tsv <clade_tsv> --out_tsv <out_tsv>
+    nextclade_multiqc_info.py --db_dir <db_dir> --clade_tsv <clade_tsv> --out_tsv <out_tsv>
 
 Reads the Nextclade TSV file and adds database version information from pathogen.json.
 """
 
-import os
-import sys
-import json
 import argparse
-import zipfile
+import json
+import logging
+import os
+import pandas as pd
 import shutil
+import sys
+import zipfile
 
-
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Augment Nextclade TSV with database info for MultiQC"
-    )
-    parser.add_argument("--db_dir", required=True, help="Directory containing pathogen.json")
-    parser.add_argument("--clade_tsv", required=True, help="Input Nextclade TSV file")
-    parser.add_argument("--out_tsv", required=True, help="Output TSV file")
-    return parser.parse_args()
-
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
 def prepare_db_dir(db_dir):
+    """Extract ZIP if provided, else return directory path."""
     if zipfile.is_zipfile(db_dir):
         folder_name = os.path.splitext(os.path.basename(db_dir))[0]
         shutil.rmtree(folder_name, ignore_errors=True)
-        with zipfile.ZipFile(db_dir, 'r') as zip_ref:
+        logging.info("Extracting database ZIP %s to %s", db_dir, folder_name)
+        with zipfile.ZipFile(db_dir, "r") as zip_ref:
             zip_ref.extractall(folder_name)
         return folder_name
-    else:
-        return db_dir
+    return db_dir
+
 
 def find_pathogen_json(db_path):
+    """Locate pathogen.json in the given directory."""
     json_file = os.path.join(db_path, "pathogen.json")
     if os.path.isfile(json_file):
         return json_file
@@ -49,82 +45,103 @@ def find_pathogen_json(db_path):
 
 
 def build_db_info(json_path):
-    with open(json_path) as fh:
+    """Extract dataset info from pathogen.json."""
+    with open(json_path, encoding="utf-8") as fh:
         data = json.load(fh)
-    name = data.get("attributes", {}).get("name") or data.get("name")
+
+    name = data.get("attributes", {}).get("name") or data.get("name", "Unknown")
     ref_name = (
         data.get("attributes", {}).get("reference name")
-        or (data.get("reference", {}).get("name") if data.get("reference") else None)
+        or data.get("reference", {}).get("name", "Unknown")
     )
     ref_acc = (
         data.get("attributes", {}).get("reference accession")
-        or (data.get("reference", {}).get("accession") if data.get("reference") else None)
+        or data.get("reference", {}).get("accession", "Unknown")
     )
+
     version = None
     if isinstance(data.get("version"), dict):
         version = data.get("version").get("tag") or data.get("version").get("name")
     else:
         version = data.get("version")
+
     return {
         "nextclade_dataset": {
-            "name": name or "Unknown",
-            "reference": {
-                "name": ref_name or "Unknown",
-                "accession": ref_acc or "Unknown",
-            },
+            "name": name,
+            "reference": {"name": ref_name, "accession": ref_acc},
             "version": version or "Unknown",
         }
     }
 
 
 def update_tsv(clade_tsv, out_tsv, db_info):
-    db = db_info.get("nextclade_dataset", {})
-    dataset_name = db.get("name", "Unknown")
-    version = db.get("version", "Unknown")
-    reference = db.get("reference", {})
-    reference_name = reference.get("name", "Unknown")
-    reference_accession = reference.get("accession", "Unknown")
-
-    db_columns = [
-        "nextclade_db_name",
-        "nextclade_db_version",
-        "nextclade_db_reference_name",
-        "nextclade_db_reference_accession",
-    ]
-    db_values = [dataset_name, version, reference_name, reference_accession]
-
+    """Append database info columns to TSV."""
     if not os.path.isfile(clade_tsv):
-        sys.stderr.write(f"Error: Input TSV file {clade_tsv} not found\n")
+        logging.error("Input TSV file %s not found", clade_tsv)
         return 1
 
-    with open(clade_tsv) as fh:
-        header = fh.readline().rstrip("\n").split("\t")
-        rows = [line.rstrip("\n").split("\t") for line in fh if line.strip()]
+    logging.info("Reading TSV with pandas")
+    try:
+        df = pd.read_csv(clade_tsv, sep="\t")
+    except Exception as e:
+        logging.error("Failed to read TSV: %s", e)
+        return 6
 
-    with open(out_tsv, "w") as fh:
-        fh.write("\t".join(header + db_columns) + "\n")
-        for row in rows:
-            if len(row) < len(header):
-                row += [""] * (len(header) - len(row))
-            fh.write("\t".join(row + db_values) + "\n")
+    if df.empty or len(df.columns) < 2:
+        logging.error("Invalid TSV: empty or missing header")
+        return 5
 
+    db = db_info.get("nextclade_dataset", {})
+    logging.info("Adding database info columns")
+    df["nextclade_db_name"] = db.get("name", "Unknown")
+    df["nextclade_db_version"] = db.get("version", "Unknown")
+    df["nextclade_db_reference_name"] = db.get("reference", {}).get("name", "Unknown")
+    df["nextclade_db_reference_accession"] = db.get("reference", {}).get("accession", "Unknown")
+
+    logging.info("Writing updated TSV to %s", out_tsv)
+    try:
+        df.to_csv(out_tsv, sep="\t", index=False)
+    except Exception as e:
+        logging.error("Failed to write TSV: %s", e)
+        return 7
+
+    logging.info("TSV update completed successfully.")
     return 0
 
 
-def main():
-    args = parse_args()
-    db_dir = prepare_db_dir(args.db_dir)
-    clade_tsv = args.clade_tsv
-    out_tsv = args.out_tsv
+class CompileResults(argparse.ArgumentParser):
+    """Custom ArgumentParser that prints help on error."""
 
-    json_file = find_pathogen_json(db_dir)
-    if json_file is None:
-        sys.stderr.write(f"Error: pathogen.json not found in {db_dir}\n")
-        return 2
-
-    info = build_db_info(json_file)
-    return update_tsv(clade_tsv, out_tsv, info)
+    def error(self, message):
+        self.print_help()
+        sys.stderr.write(f"\nERROR DETECTED: {message}\n")
+        sys.exit(1)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    parser = CompileResults(
+        prog="nextclade_multiqc_info.py",
+        description="Update Nextclade TSV with database info for MultiQC",
+        epilog="Example usage: python nextclade_multiqc_info.py --db_dir <db_dir> --clade_tsv <clade_tsv> --out_tsv <out_tsv>"
+    )
+
+    parser.add_argument("--db_dir", required=True, help="Directory containing pathogen.json or ZIP")
+    parser.add_argument("--clade_tsv", required=True, help="Input Nextclade TSV file")
+    parser.add_argument("--out_tsv", required=True, help="Output TSV file")
+
+    args = parser.parse_args()
+
+    logging.info("Preparing database directory")
+    db_dir = prepare_db_dir(args.db_dir)
+
+    logging.info("Finding pathogen.json")
+    json_file = find_pathogen_json(db_dir)
+    if json_file is None:
+        logging.error("pathogen.json not found in %s", db_dir)
+        sys.exit(2)
+
+    logging.info("Building database info")
+    info = build_db_info(json_file)
+
+    logging.info("Updating TSV file with pandas")
+    sys.exit(update_tsv(args.clade_tsv, args.out_tsv, info))

--- a/bin/nextclade_multiqc_info.py
+++ b/bin/nextclade_multiqc_info.py
@@ -50,13 +50,9 @@ def build_db_info(json_path):
         data = json.load(fh)
 
     name = data.get("attributes", {}).get("name") or data.get("name", "Unknown")
-    ref_name = (
-        data.get("attributes", {}).get("reference name")
-        or data.get("reference", {}).get("name", "Unknown")
-    )
-    ref_acc = (
-        data.get("attributes", {}).get("reference accession")
-        or data.get("reference", {}).get("accession", "Unknown")
+    ref_name = data.get("attributes", {}).get("reference name") or data.get("reference", {}).get("name", "Unknown")
+    ref_acc = data.get("attributes", {}).get("reference accession") or data.get("reference", {}).get(
+        "accession", "Unknown"
     )
 
     version = None
@@ -122,7 +118,7 @@ if __name__ == "__main__":
     parser = CompileResults(
         prog="nextclade_multiqc_info.py",
         description="Update Nextclade TSV with database info for MultiQC",
-        epilog="Example usage: python nextclade_multiqc_info.py --db_dir <db_dir> --clade_tsv <clade_tsv> --out_tsv <out_tsv>"
+        epilog="Example usage: python nextclade_multiqc_info.py --db_dir <db_dir> --clade_tsv <clade_tsv> --out_tsv <out_tsv>",
     )
 
     parser.add_argument("--db_dir", required=True, help="Directory containing pathogen.json or ZIP")

--- a/bin/nextclade_multiqc_info.py
+++ b/bin/nextclade_multiqc_info.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Edit Nextclade TSV file for MultiQC to include the database name,
+version, and reference accession number for each sample processed by nextclade_run.
+
+Usage:
+  nextclade_multiqc_info.py --db_dir <db_dir> --clade_tsv <clade_tsv> --out_tsv <out_tsv>
+
+Reads the Nextclade TSV file and adds database version information from pathogen.json.
+"""
+
+import os
+import sys
+import json
+import argparse
+import zipfile
+import shutil
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Augment Nextclade TSV with database info for MultiQC"
+    )
+    parser.add_argument("--db_dir", required=True, help="Directory containing pathogen.json")
+    parser.add_argument("--clade_tsv", required=True, help="Input Nextclade TSV file")
+    parser.add_argument("--out_tsv", required=True, help="Output TSV file")
+    return parser.parse_args()
+
+
+
+def prepare_db_dir(db_dir):
+    if zipfile.is_zipfile(db_dir):
+        folder_name = os.path.splitext(os.path.basename(db_dir))[0]
+        shutil.rmtree(folder_name, ignore_errors=True)
+        with zipfile.ZipFile(db_dir, 'r') as zip_ref:
+            zip_ref.extractall(folder_name)
+        return folder_name
+    else:
+        return db_dir
+
+def find_pathogen_json(db_path):
+    json_file = os.path.join(db_path, "pathogen.json")
+    if os.path.isfile(json_file):
+        return json_file
+    for root, _, files in os.walk(db_path):
+        if "pathogen.json" in files:
+            return os.path.join(root, "pathogen.json")
+    return None
+
+
+def build_db_info(json_path):
+    with open(json_path) as fh:
+        data = json.load(fh)
+    name = data.get("attributes", {}).get("name") or data.get("name")
+    ref_name = (
+        data.get("attributes", {}).get("reference name")
+        or (data.get("reference", {}).get("name") if data.get("reference") else None)
+    )
+    ref_acc = (
+        data.get("attributes", {}).get("reference accession")
+        or (data.get("reference", {}).get("accession") if data.get("reference") else None)
+    )
+    version = None
+    if isinstance(data.get("version"), dict):
+        version = data.get("version").get("tag") or data.get("version").get("name")
+    else:
+        version = data.get("version")
+    return {
+        "nextclade_dataset": {
+            "name": name or "Unknown",
+            "reference": {
+                "name": ref_name or "Unknown",
+                "accession": ref_acc or "Unknown",
+            },
+            "version": version or "Unknown",
+        }
+    }
+
+
+def update_tsv(clade_tsv, out_tsv, db_info):
+    db = db_info.get("nextclade_dataset", {})
+    dataset_name = db.get("name", "Unknown")
+    version = db.get("version", "Unknown")
+    reference = db.get("reference", {})
+    reference_name = reference.get("name", "Unknown")
+    reference_accession = reference.get("accession", "Unknown")
+
+    db_columns = [
+        "nextclade_db_name",
+        "nextclade_db_version",
+        "nextclade_db_reference_name",
+        "nextclade_db_reference_accession",
+    ]
+    db_values = [dataset_name, version, reference_name, reference_accession]
+
+    if not os.path.isfile(clade_tsv):
+        sys.stderr.write(f"Error: Input TSV file {clade_tsv} not found\n")
+        return 1
+
+    with open(clade_tsv) as fh:
+        header = fh.readline().rstrip("\n").split("\t")
+        rows = [line.rstrip("\n").split("\t") for line in fh if line.strip()]
+
+    with open(out_tsv, "w") as fh:
+        fh.write("\t".join(header + db_columns) + "\n")
+        for row in rows:
+            if len(row) < len(header):
+                row += [""] * (len(header) - len(row))
+            fh.write("\t".join(row + db_values) + "\n")
+
+    return 0
+
+
+def main():
+    args = parse_args()
+    db_dir = prepare_db_dir(args.db_dir)
+    clade_tsv = args.clade_tsv
+    out_tsv = args.out_tsv
+
+    json_file = find_pathogen_json(db_dir)
+    if json_file is None:
+        sys.stderr.write(f"Error: pathogen.json not found in {db_dir}\n")
+        return 2
+
+    info = build_db_info(json_file)
+    return update_tsv(clade_tsv, out_tsv, info)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conf/wslh.config
+++ b/conf/wslh.config
@@ -34,7 +34,7 @@ process {
                 pattern: '*variants_metrics_mqc.csv',
                 enabled: !params.skip_variants,
                 saveAs: { filename -> 
-                    params.runname ? "${params.runname}_rsv_viralrecon_report.csv" : "${workflow.runName}_rsv_viralrecon_report.csv"
+                    params.runname ? "${params.runname}_${params.genome}_viralrecon_report.csv" : "${workflow.runName}_${params.genome}_viralrecon_report.csv"
                 }
             ],
             [

--- a/modules/local/multiqc_illumina.nf
+++ b/modules/local/multiqc_illumina.nf
@@ -66,7 +66,7 @@ process MULTIQC {
     rm -f variants/report.tsv
 
     ## Run MultiQC a second time
-    multiqc -f $args -e general_stats --ignore nextclade_clade_mqc.tsv $custom_config .
+    multiqc -f $args -e general_stats --ignore nextclade_clade_db_info_mqc.tsv $custom_config .
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/nextclade_multiqc_info.nf
+++ b/modules/local/nextclade_multiqc_info.nf
@@ -20,7 +20,7 @@ process NEXTCLADE_MULTIQC_INFO {
 
     script:
     """
-    nextclade_multiqc_info.py $db nextclade_clade_db_info_mqc.tsv $clade_tsv
+    nextclade_multiqc_info.py --db_dir $db --clade_tsv $clade_tsv --out_tsv nextclade_clade_db_info_mqc.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/nextclade_multiqc_info.nf
+++ b/modules/local/nextclade_multiqc_info.nf
@@ -1,0 +1,30 @@
+process NEXTCLADE_MULTIQC_INFO {
+    tag "$db"
+    label 'process_medium'
+
+    conda "conda-forge::python=3.8"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.8' :
+        'quay.io/biocontainers/python:3.8' }"
+
+    input:
+    path db
+    path clade_tsv
+
+    output:
+    path "nextclade_clade_db_info_mqc.tsv", emit: tsv
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    nextclade_multiqc_info.py $db nextclade_clade_db_info_mqc.tsv $clade_tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/modules/local/nextclade_multiqc_info.nf
+++ b/modules/local/nextclade_multiqc_info.nf
@@ -2,10 +2,10 @@ process NEXTCLADE_MULTIQC_INFO {
     tag "$db"
     label 'process_medium'
 
-    conda "conda-forge::python=3.8"
+    conda "conda-forge::pandas:2.2.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/python:3.8' :
-        'quay.io/biocontainers/python:3.8' }"
+        'https://depot.galaxyproject.org/singularity/pandas:2.2.1' :
+        'quay.io/biocontainers/pandas:2.2.1' }"
 
     input:
     path db

--- a/nextflow.config
+++ b/nextflow.config
@@ -262,13 +262,13 @@ dag {
 }
 
 manifest {
-    name            = 'nf-core/viralrecon'
+    name            = 'wslh-bio/viralrecon'
     author          = """Patel H, Varona S and Monzon S"""
-    homePage        = 'https://github.com/nf-core/viralrecon'
+    homePage        = 'https://github.com/wslh-bio/viralrecon'
     description     = """Assembly and intrahost/low-frequency variant calling for viral samples"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = 'RSV-Viralrecon-v2.6.0-v1.0.0'
+    version         = 'RSV-Viralrecon-v2.6.0-v1.1.0'
     doi             = 'https://doi.org/10.5281/zenodo.3901628'
 }
 

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -59,6 +59,7 @@ include { CUTADAPT } from '../modules/local/cutadapt'
 include { MULTIQC  } from '../modules/local/multiqc_illumina'
 include { PLOT_MOSDEPTH_REGIONS as PLOT_MOSDEPTH_REGIONS_GENOME   } from '../modules/local/plot_mosdepth_regions'
 include { PLOT_MOSDEPTH_REGIONS as PLOT_MOSDEPTH_REGIONS_AMPLICON } from '../modules/local/plot_mosdepth_regions'
+include { NEXTCLADE_MULTIQC_INFO } from '../modules/local/nextclade_multiqc_info'
 
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
@@ -497,22 +498,32 @@ workflow ILLUMINA {
     }
 
     //
-    // MODULE: Get Nextclade clade information for MultiQC report
+    // MODULE: Get Nextclade database and clade information for MultiQC report
     //
     ch_nextclade_multiqc = Channel.empty()
     if (!params.skip_nextclade) {
         ch_nextclade_report
             .map { meta, csv ->
                 def clade = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['clade']
-                return [ "$meta.id\t$clade" ]
+                def qcscore = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['qc.overallScore']
+                def qcstatus = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['qc.overallStatus']
+                def coverage = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['coverage']
+                return [ "$meta.id\t$clade\t$qcscore\t$qcstatus\t$coverage" ]
             }
             .collect()                
             .map { 
                 tsv_data ->
-                    def header = ['Sample', 'clade']
+                    def header = ['Sample', 'clade', 'qc.overallScore', 'qc.overallStatus', 'coverage']
                     WorkflowCommons.multiqcTsvFromList(tsv_data, header)
             }
             .set { ch_nextclade_multiqc }
+
+        // Extract database information using dedicated module
+        NEXTCLADE_MULTIQC_INFO (
+            PREPARE_GENOME.out.nextclade_db,
+            ch_nextclade_multiqc.collectFile(name: 'nextclade_clade_mqc.tsv').ifEmpty([])
+        )
+        ch_nextclade_multiqc = NEXTCLADE_MULTIQC_INFO.out.tsv
     }
 
     //
@@ -634,7 +645,7 @@ workflow ILLUMINA {
             ch_snpeff_multiqc.collect{it[1]}.ifEmpty([]),
             ch_quast_multiqc.collect().ifEmpty([]),
             ch_pangolin_multiqc.collect{it[1]}.ifEmpty([]),
-            ch_nextclade_multiqc.collectFile(name: 'nextclade_clade_mqc.tsv').ifEmpty([]),
+            ch_nextclade_multiqc.collectFile(name: 'nextclade_clade_db_info_mqc.tsv').ifEmpty([]),
             ch_cutadapt_multiqc.collect{it[1]}.ifEmpty([]),
             ch_spades_quast_multiqc.collect().ifEmpty([]),
             ch_unicycler_quast_multiqc.collect().ifEmpty([]),

--- a/workflows/illumina.nf
+++ b/workflows/illumina.nf
@@ -508,12 +508,17 @@ workflow ILLUMINA {
                 def qcscore = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['qc.overallScore']
                 def qcstatus = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['qc.overallStatus']
                 def coverage = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['coverage']
-                return [ "$meta.id\t$clade\t$qcscore\t$qcstatus\t$coverage" ]
+                def substitutions = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['totalSubstitutions']
+                def deletions = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['totalDeletions']
+                def insertions = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['totalInsertions']
+                def frameshifts = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['totalFrameShifts']
+                def missing = WorkflowCommons.getNextcladeFieldMapFromCsv(csv)['totalMissing']
+                return [ "$meta.id\t$clade\t$qcscore\t$qcstatus\t$coverage\t$substitutions\t$deletions\t$insertions\t$frameshifts\t$missing" ]
             }
             .collect()                
             .map { 
                 tsv_data ->
-                    def header = ['Sample', 'clade', 'qc.overallScore', 'qc.overallStatus', 'coverage']
+                    def header = ['Sample', 'clade', 'qc.overallScore', 'qc.overallStatus', 'coverage', 'totalSubstitutions', 'totalDeletions', 'totalInsertions', 'totalFrameShifts', 'totalMissing']
                     WorkflowCommons.multiqcTsvFromList(tsv_data, header)
             }
             .set { ch_nextclade_multiqc }


### PR DESCRIPTION
This update does the following: 

- Updated the final report to include nextclade database and metric information.
- Addition of nextclade_multiqc_info module to add database information from nextclade database brought into the pipeline.
- Addition of python script for nextclade_multiqc_info module to merge database information into tsv file for nextclade multiqc data.
- Edited multiqc_to_custom_csv.py and multiqc_config_illumina.yml files to include addtional nextclade data.
- Edited illumina.nf to include new module and include more columns in nextclade data channel.
- Added the params.genome to the naming convention for reports to add rsva or rsvb to report name.

The Multiqc module and script prepare the report, so data that we want to include should be included in inputs for that module. This change adds a module that adds nextclade database version information to the report with a python script that reads the database json file for specific information. Configuration files are updated to help create the report file as well.